### PR TITLE
Fix constructor visibility issue

### DIFF
--- a/src/main/java/org/braid/society/secret/misskrient/internal/mfm/AbstractMfmNode.java
+++ b/src/main/java/org/braid/society/secret/misskrient/internal/mfm/AbstractMfmNode.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import org.braid.society.secret.misskrient.api.mfm.MfmNode;
 
-@NoArgsConstructor(access = AccessLevel.PACKAGE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class AbstractMfmNode implements MfmNode {
 
   protected List<MfmNode> children;


### PR DESCRIPTION
The constructor of `AbstructMfmNode` which takes no arguments has been set to `PROTECTED` instead of `PACKAGE`